### PR TITLE
Include files_to_skip into create_imagenet_spec

### DIFF
--- a/meta_dataset/dataset_conversion/dataset_to_records.py
+++ b/meta_dataset/dataset_conversion/dataset_to_records.py
@@ -1407,12 +1407,37 @@ class ImageNetConverter(DatasetConverter):
 
     See HierarchicalDatasetSpecification for details.
     """
+    # Load lists of image names that are duplicates with images in other
+    # datasets. They will be skipped from ImageNet.
+    self.files_to_skip = set()
+    for other_dataset in ('Caltech101', 'Caltech256', 'CUBirds'):
+        duplicates_file = os.path.join(
+            ILSCRC_DUPLICATES_PATH,
+            'ImageNet_{}_duplicates.txt'.format(other_dataset))
+
+        with tf.gfile.Open(duplicates_file) as fd:
+            duplicates = fd.read()
+        lines = duplicates.splitlines()
+
+        for l in lines:
+            # Skip comment lines
+            l = l.strip()
+            if l.startswith('#'):
+                continue
+            # Lines look like:
+            # 'synset/synset_imgnumber.JPEG  # original_file_name.jpg\n'.
+            # Extract only the 'synset_imgnumber.JPG' part.
+            file_path = l.split('#')[0].strip()
+            file_name = os.path.basename(file_path)
+            self.files_to_skip.add(file_name)
+
     ilsvrc_2012_num_leaf_images_path = FLAGS.ilsvrc_2012_num_leaf_images_path
     if not ilsvrc_2012_num_leaf_images_path:
       ilsvrc_2012_num_leaf_images_path = os.path.join(self.records_path,
                                                       'num_leaf_images.pkl')
     specification = imagenet_specification.create_imagenet_specification(
-        learning_spec.Split, ilsvrc_2012_num_leaf_images_path)
+        learning_spec.Split, self.files_to_skip,
+        ilsvrc_2012_num_leaf_images_path)
     split_subgraphs, images_per_class, _, _, _, _ = specification
 
     # Maps each class id to the name of its class.
@@ -1421,6 +1446,7 @@ class ImageNetConverter(DatasetConverter):
     self.dataset_spec = ds_spec.HierarchicalDatasetSpecification(
         self.name, split_subgraphs, images_per_class, self.class_names,
         self.records_path, '{}.tfrecords')
+
 
   def _get_synset_ids(self, split):
     """Returns a list of synset id's of the classes assigned to split."""
@@ -1434,30 +1460,6 @@ class ImageNetConverter(DatasetConverter):
 
     The field that requires modification in this case is only self.class_names.
     """
-    # Load lists of image names that are duplicates with images in other
-    # datasets. They will be skipped from ImageNet.
-    files_to_skip = set()
-    for other_dataset in ('Caltech101', 'Caltech256', 'CUBirds'):
-      duplicates_file = os.path.join(
-          ILSCRC_DUPLICATES_PATH,
-          'ImageNet_{}_duplicates.txt'.format(other_dataset))
-
-      with tf.gfile.Open(duplicates_file) as fd:
-        duplicates = fd.read()
-      lines = duplicates.splitlines()
-
-      for l in lines:
-        # Skip comment lines
-        l = l.strip()
-        if l.startswith('#'):
-          continue
-        # Lines look like:
-        # 'synset/synset_imgnumber.JPEG  # original_file_name.jpg\n'.
-        # Extract only the 'synset_imgnumber.JPG' part.
-        file_path = l.split('#')[0].strip()
-        file_name = os.path.basename(file_path)
-        files_to_skip.add(file_name)
-
     # Get a list of synset id's assigned to each split.
     train_synset_ids = self._get_synset_ids(learning_spec.Split.TRAIN)
     valid_synset_ids = self._get_synset_ids(learning_spec.Split.VALID)
@@ -1490,7 +1492,7 @@ class ImageNetConverter(DatasetConverter):
           class_path,
           class_label,
           class_records_path,
-          files_to_skip=files_to_skip,
+          files_to_skip=self.files_to_skip,
           skip_on_error=True)
 
 


### PR DESCRIPTION
Currently, the number of images per class is calculated with a [listdir](https://github.com/google-research/meta-dataset/blob/master/meta_dataset/data/imagenet_specification.py#L811) operation that does not take into account the files skipped when reading. As a result, the `Reader` cursors are misaligned, making it possible to have the same sample in the support and query set (https://github.com/google-research/meta-dataset/blob/master/meta_dataset/data/reader.py#L107).

This PR introduces `files_to_skip` into the ImageNet specification and the dataset converter to avoid this problem.

