### PR TITLE
Updated typo

### DIFF
--- a/Intro_to_Metadataset.ipynb
+++ b/Intro_to_Metadataset.ipynb
@@ -425,7 +425,7 @@
         "1. `meta_dataset` library provides option to set number of classes/samples per episode. There are 3 main flags you can set. \n",
         "    - **NUM_WAYS**: Fixes the # classes per episode. We would still get variable number of samples per class in the support set.\n",
         "    - **NUM_SUPPORT**: Fixes # samples per class in the support set.\n",
-        "    - **NUM_SUPPORT**: Fixes # samples per class in the query set.\n",
+        "    - **NUM_QUERY**: Fixes # samples per class in the query set.\n",
         "2. If we want to use fixed `num_ways`, we have to disable ontology based sampling for omniglot and imagenet. We advise using single dataset for using this feature, since using multiple datasets is not supported/tested. In this notebook, we are using Quick, Draw! Dataset.\n",
         "3. We sample episodes and visualize them as we did earlier."
       ]


### PR DESCRIPTION
Updated the typo for Fixing Ways and Shots section. "NUM_QUERY" was wrongly named as "NUM_SUPPORT"